### PR TITLE
Headless Codeforces scraper (no chrome window/GUI will open)

### DIFF
--- a/CodeForcesScraper.py
+++ b/CodeForcesScraper.py
@@ -57,7 +57,9 @@ def get_solutions(username, all_info=None):
         sub_id_info[info['solution_id']] = info
 
     options = Options()
-    options.add_argument('--start-maximized')
+    options.add_argument('headless')
+    options.add_argument('window-size=1920x1080')
+    options.add_argument("disable-gpu")
 
     driver = webdriver.Chrome(ChromeDriverManager().install(), options=options)
     driver.get(f'https://codeforces.com/submissions/{username}')


### PR DESCRIPTION
Why not run selenium in headless mode? It should be less resource intensive, faster, and distract the user less. I tried this locally, and it worked great.